### PR TITLE
Add refresh tokens locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ try {
 
 #### Authentication
 
-Authentication method for verifying access and refresh tokens and scheduling tokens refreshing.
+Authentication method for verifying access and refresh tokens.
 
 ```js
 const getTokens = () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cadolabs/auther-client",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "main": "dist/auther-client.cjs.js",
   "module": "dist/auther-client.es.js",
   "description": "Client for working with auther on the frontend side",

--- a/src/client/AutherClient.js
+++ b/src/client/AutherClient.js
@@ -12,12 +12,13 @@ export class AutherClient {
   #LOGIN_PATH = "/login"
   #DISPOSABLE_TOKEN_PATH = "/tokens/disposable"
 
-  constructor ({ redirectUri, autherUrl, http, appcode, logger }) {
+  constructor ({ redirectUri, autherUrl, http, appcode, logger, onError }) {
     this.redirectUri = redirectUri
     this.autherUrl = autherUrl
     this.http = http
     this.appcode = appcode
     this.logger = logger
+    this.onError = onError
   }
 
   #buildOauthUrl = () => {
@@ -30,18 +31,34 @@ export class AutherClient {
     return redirectUrl.toString()
   }
 
-  #refreshTokens = async ({ getTokens, saveTokens }) => {
-    const currentTime = `${new Date()} [${new Date().toUTCString()}]`
-    const { refreshToken } = getTokens()
+  refreshTokens = async ({ getTokens, saveTokens }) => {
+    const tokenBefore = getTokens().refreshToken
 
-    verify(refreshToken)
+    const doRefresh = async () => {
+      const { refreshToken } = getTokens()
 
-    const response = await this.updateTokens(refreshToken)
-    const tokens = await response.json()
+      if (refreshToken !== tokenBefore) {
+        return getTokens()
+      }
 
-    saveTokens(tokens)
+      verify(refreshToken)
+      const response = await this.updateTokens(refreshToken)
 
-    this.logger.log(`Token has been refreshed successfully at ${currentTime}`)
+      if (!response.ok) {
+        throw new Error("refresh.failed")
+      }
+
+      const tokens = await response.json()
+      saveTokens(tokens)
+      this.logger.log(`Token has been refreshed successfully at ${new Date().toUTCString()}`)
+      return tokens
+    }
+
+    if (typeof navigator !== "undefined" && navigator.locks) {
+      return navigator.locks.request("auth_refresh", doRefresh)
+    }
+
+    return doRefresh()
   }
 
   #scheduleTokensRefreshing = ({ getTokens, saveTokens }) => {
@@ -72,13 +89,14 @@ export class AutherClient {
 
     setTimeout(async () => {
       try {
-        await this.#refreshTokens({ getTokens, saveTokens })
+        await this.refreshTokens({ getTokens, saveTokens })
         this.#scheduleTokensRefreshing({ getTokens, saveTokens })
       }
       catch (error) {
         this.logger.error(
           `Error during tokens refreshing at ${new Date()} [${new Date().toUTCString()}]`,
         )
+        this.onError?.(error)
       }
     }, refreshTimeout)
   }
@@ -123,7 +141,7 @@ export class AutherClient {
       verify(accessToken)
     }
     catch (err) {
-      await this.#refreshTokens({ getTokens, saveTokens })
+      await this.refreshTokens({ getTokens, saveTokens })
     }
 
     this.#scheduleTokensRefreshing({ getTokens, saveTokens })

--- a/src/client/AutherClient.js
+++ b/src/client/AutherClient.js
@@ -1,7 +1,4 @@
-import { verify, decode } from "../lib/jwt"
-
-const ONE_MINUTE_MS = 60 * 1000
-const ONE_DAY_MS = 24 * 60 * 60 * 1000
+import { verify } from "../lib/jwt"
 
 export class AutherClient {
   #location = window.location
@@ -12,13 +9,12 @@ export class AutherClient {
   #LOGIN_PATH = "/login"
   #DISPOSABLE_TOKEN_PATH = "/tokens/disposable"
 
-  constructor ({ redirectUri, autherUrl, http, appcode, logger, onError }) {
+  constructor ({ redirectUri, autherUrl, http, appcode, logger }) {
     this.redirectUri = redirectUri
     this.autherUrl = autherUrl
     this.http = http
     this.appcode = appcode
     this.logger = logger
-    this.onError = onError
   }
 
   #buildOauthUrl = () => {
@@ -59,46 +55,6 @@ export class AutherClient {
     }
 
     return doRefresh()
-  }
-
-  #scheduleTokensRefreshing = ({ getTokens, saveTokens }) => {
-    const { accessToken } = getTokens()
-
-    verify(accessToken)
-
-    const decodedToken = decode(accessToken)
-
-    if (decodedToken.payload.temp) return false
-
-    const tokenExpDateMs = decodedToken.payload.exp * 1000
-    let refreshTimeout = (tokenExpDateMs - new Date()) / 2
-
-    if (refreshTimeout < ONE_MINUTE_MS) {
-      refreshTimeout = ONE_MINUTE_MS
-    }
-
-    if (refreshTimeout > ONE_DAY_MS) {
-      refreshTimeout = ONE_DAY_MS
-    }
-
-    const tokenExpDate = new Date(tokenExpDateMs)
-    const refreshDate = new Date(Date.now() + refreshTimeout)
-
-    this.logger.log(`Token will expire at ${(tokenExpDate)} [${tokenExpDate.toUTCString()}]`)
-    this.logger.log(`Token will be refreshed at ${refreshDate} [${refreshDate.toUTCString()}]`)
-
-    setTimeout(async () => {
-      try {
-        await this.refreshTokens({ getTokens, saveTokens })
-        this.#scheduleTokensRefreshing({ getTokens, saveTokens })
-      }
-      catch (error) {
-        this.logger.error(
-          `Error during tokens refreshing at ${new Date()} [${new Date().toUTCString()}]`,
-        )
-        this.onError?.(error)
-      }
-    }, refreshTimeout)
   }
 
   login = () => {
@@ -143,8 +99,6 @@ export class AutherClient {
     catch (err) {
       await this.refreshTokens({ getTokens, saveTokens })
     }
-
-    this.#scheduleTokensRefreshing({ getTokens, saveTokens })
   }
 
   fetchDisposableTokensById = ({ id, headers }) => {

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -3,13 +3,14 @@ import { doFetch } from "../lib/http"
 import { AutherClient } from "./AutherClient"
 
 export default class {
-  static init ({ redirectUri, autherUrl, appcode, logger = console }) {
+  static init ({ redirectUri, autherUrl, appcode, logger = console, onError }) {
     return new AutherClient({
       http: doFetch(autherUrl),
       redirectUri,
       autherUrl,
       appcode,
       logger,
+      onError,
     })
   }
 }

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -3,14 +3,13 @@ import { doFetch } from "../lib/http"
 import { AutherClient } from "./AutherClient"
 
 export default class {
-  static init ({ redirectUri, autherUrl, appcode, logger = console, onError }) {
+  static init ({ redirectUri, autherUrl, appcode, logger = console }) {
     return new AutherClient({
       http: doFetch(autherUrl),
       redirectUri,
       autherUrl,
       appcode,
       logger,
-      onError,
     })
   }
 }

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -173,6 +173,9 @@ describe("When use auther methods", () => {
   describe("authenticate method", () => {
     beforeEach(() => {
       jest.useFakeTimers()
+      window.navigator.locks = {
+        request: (_name, callback) => callback(),
+      }
     })
 
     it("should authenticate with actual tokens", async () => {
@@ -304,6 +307,128 @@ describe("When use auther methods", () => {
       expect(mockLogger.log).toHaveBeenCalledWith(
         `Token will be refreshed at ${expectedRefreshDate} [${expectedRefreshDate.toUTCString()}]`,
       )
+    })
+
+    it("should not call saveTokens when refresh endpoint returns error response", async () => {
+      fetch.resetMocks()
+      const auth = createAutherClient()
+
+      fetch.mockResponseOnce(JSON.stringify({ error: "token_invalid" }), { status: 401 })
+
+      const expiredDate = new Date()
+      expiredDate.setHours(expiredDate.getHours() - 3)
+
+      const saveTokensMock = jest.fn()
+      const { getTokens } = getAuthCallbacks({ accessTokenExpDate: expiredDate })
+
+      await expect(auth.authentication({ getTokens, saveTokens: saveTokensMock }))
+        .rejects
+        .toThrow("refresh.failed")
+
+      expect(saveTokensMock).not.toHaveBeenCalled()
+    })
+
+    it("should not call saveTokens when scheduled refresh returns error response", async () => {
+      const mockLogger = { log: jest.fn(), error: jest.fn() }
+      const auth = createAutherClient({ logger: mockLogger })
+
+      fetch.mockResponseOnce(JSON.stringify({ error: "token_invalid" }), { status: 401 })
+
+      const saveTokensMock = jest.fn()
+      const { getTokens } = getAuthCallbacks()
+
+      await auth.authentication({ getTokens, saveTokens: saveTokensMock })
+
+      jest.runAllTimers()
+      // // flush microtasks from the async timer callback and fetch mock chain
+      for (let i = 0; i < 10; i += 1) { await Promise.resolve() }
+
+      expect(saveTokensMock).not.toHaveBeenCalled()
+      expect(mockLogger.error).toHaveBeenCalled()
+    })
+
+    it("should not call onError when it is not provided and scheduled refresh fails", async () => {
+      const mockLogger = { log: jest.fn(), error: jest.fn() }
+      const auth = createAutherClient({ logger: mockLogger })
+
+      fetch.mockResponseOnce(JSON.stringify({ error: "token_invalid" }), { status: 401 })
+
+      const saveTokensMock = jest.fn()
+      const { getTokens } = getAuthCallbacks()
+
+      await auth.authentication({ getTokens, saveTokens: saveTokensMock })
+
+      jest.runAllTimers()
+      for (let i = 0; i < 10; i += 1) { await Promise.resolve() }
+
+      expect(mockLogger.error).toHaveBeenCalled()
+      // should not throw when onError is not provided
+    })
+
+    it("calls onError when scheduled refresh fails", async () => {
+      const onErrorMock = jest.fn()
+      const mockLogger = { log: jest.fn(), error: jest.fn() }
+      const auth = createAutherClient({ logger: mockLogger, onError: onErrorMock })
+
+      fetch.mockResponseOnce(JSON.stringify({ error: "token_invalid" }), { status: 401 })
+
+      const saveTokensMock = jest.fn()
+      const { getTokens } = getAuthCallbacks()
+
+      await auth.authentication({ getTokens, saveTokens: saveTokensMock })
+
+      jest.runAllTimers()
+      for (let i = 0; i < 10; i += 1) { await Promise.resolve() }
+
+      expect(onErrorMock).toHaveBeenCalledWith(expect.any(Error))
+      expect(onErrorMock.mock.calls[0][0].message).toBe("refresh.failed")
+    })
+
+    it("returns current tokens without fetch when refreshToken changed before lock", async () => {
+      const newTokens = { accessToken: "new-access", refreshToken: "different-refresh" }
+      let callCount = 0
+      window.navigator.locks = {
+        request: async (_name, callback) => {
+          callCount += 1
+          return callback()
+        },
+      }
+
+      const auth = createAutherClient()
+      const { getTokens: getTokensOrig, saveTokens } = getAuthCallbacks()
+      const origRefreshToken = getTokensOrig().refreshToken
+      const getTokens = () => {
+        if (callCount > 0) return newTokens
+        return { accessToken: getTokensOrig().accessToken, refreshToken: origRefreshToken }
+      }
+
+      fetch.resetMocks()
+      const result = await auth.refreshTokens({ getTokens, saveTokens })
+
+      expect(fetch).not.toHaveBeenCalled()
+      expect(result).toEqual(newTokens)
+    })
+
+    it("falls back to direct call when navigator.locks is unavailable", async () => {
+      const savedLocks = window.navigator.locks
+      delete window.navigator.locks
+
+      try {
+        const newTokens = { accessToken: "new", refreshToken: "new-r" }
+        fetch.mockResponseOnce(JSON.stringify(newTokens))
+
+        const auth = createAutherClient()
+        const saveTokensMock = jest.fn()
+        const { getTokens } = getAuthCallbacks()
+
+        const result = await auth.refreshTokens({ getTokens, saveTokens: saveTokensMock })
+
+        expect(result).toEqual(newTokens)
+        expect(saveTokensMock).toHaveBeenCalledWith(newTokens)
+      }
+      finally {
+        window.navigator.locks = savedLocks
+      }
     })
 
     it("should set max refreshTimeout to one day", async () => {

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -172,37 +172,9 @@ describe("When use auther methods", () => {
 
   describe("authenticate method", () => {
     beforeEach(() => {
-      jest.useFakeTimers()
       window.navigator.locks = {
         request: (_name, callback) => callback(),
       }
-    })
-
-    it("should authenticate with actual tokens", async () => {
-      fetch.mockResponseOnce(JSON.stringify({
-        accessToken: getAccessToken(),
-        refreshToken: getRefreshToken(),
-      }))
-
-      const auth = createAutherClient()
-      const callbacks = getAuthCallbacks()
-
-      await expect(() => auth.authentication(callbacks)).not.toThrowError()
-
-      jest.runOnlyPendingTimers()
-
-      const expectedUrl = "http://localhost/tokens/refresh"
-      const expectedBody = JSON.stringify({ refreshToken: callbacks.getTokens().refreshToken })
-      const expectedHeaders = {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-      }
-
-      expect(fetch).toHaveBeenCalledWith(expectedUrl, {
-        method: "POST",
-        body: expectedBody,
-        headers: expectedHeaders,
-      })
     })
 
     it("should authenticate with actual refresh token and expired access token", async () => {
@@ -218,8 +190,6 @@ describe("When use auther methods", () => {
       const callbacks = getAuthCallbacks({ accessTokenExpDate: expiredDate })
       await expect(() => auth.authentication(callbacks)).not.toThrowError()
 
-      jest.runOnlyPendingTimers()
-
       const expectedUrl = "http://localhost/tokens/refresh"
       const expectedBody = JSON.stringify({ refreshToken: callbacks.getTokens().refreshToken })
       const expectedHeaders = {
@@ -231,29 +201,6 @@ describe("When use auther methods", () => {
         method: "POST",
         body: expectedBody,
         headers: expectedHeaders,
-      })
-    })
-
-    it("should log error when refresh token expired", async () => {
-      fetch.mockResponseOnce(JSON.stringify({
-        accessToken: getAccessToken(),
-        refreshToken: getRefreshToken(),
-      }))
-      const mockLogger = { log: jest.fn(), error: jest.fn() }
-
-      const auth = createAutherClient({ logger: mockLogger })
-      const expiredDate = new Date()
-      expiredDate.setHours(expiredDate.getHours() - 3)
-      const callbacks = getAuthCallbacks({ refreshTokenExpDate: expiredDate })
-
-      await expect(() => auth.authentication(callbacks)).not.toThrowError()
-
-      jest.runAllTimers()
-
-      mockLogger.error.mockImplementationOnce(() => {
-        expect(mockLogger.error).toHaveBeenCalledWith(
-          `Error during tokens refreshing at ${new Date()} [${new Date().toUTCString()}]`,
-        )
       })
     })
 
@@ -273,42 +220,6 @@ describe("When use auther methods", () => {
       expect(fetch).not.toHaveBeenCalled()
     })
 
-    it("should log error when server fails to refresh tokens", async () => {
-      const mockLogger = { log: jest.fn(), error: jest.fn() }
-      const auth = createAutherClient({ logger: mockLogger })
-
-      fetch.mockRejectOnce()
-
-      const callbacks = getAuthCallbacks()
-
-      await expect(() => auth.authentication(callbacks)).not.toThrowError()
-
-      jest.runAllTimers()
-
-      mockLogger.error.mockImplementationOnce(() => {
-        expect(mockLogger.error).toHaveBeenCalledWith(
-          `Error during tokens refreshing at ${new Date()} [${new Date().toUTCString()}]`,
-        )
-      })
-    })
-
-    it("should set min refreshTimeout to one minute", async () => {
-      const mockLogger = { log: jest.fn() }
-
-      const auth = createAutherClient({ logger: mockLogger })
-      const expiredDate = new Date()
-      expiredDate.setSeconds(expiredDate.getSeconds() + 30)
-      const callbacks = getAuthCallbacks({ accessTokenExpDate: expiredDate })
-
-      await auth.authentication(callbacks)
-
-      const expectedRefreshDate = new Date(Date.now() + 60 * 1000) // one minute
-
-      expect(mockLogger.log).toHaveBeenCalledWith(
-        `Token will be refreshed at ${expectedRefreshDate} [${expectedRefreshDate.toUTCString()}]`,
-      )
-    })
-
     it("should not call saveTokens when refresh endpoint returns error response", async () => {
       fetch.resetMocks()
       const auth = createAutherClient()
@@ -326,62 +237,6 @@ describe("When use auther methods", () => {
         .toThrow("refresh.failed")
 
       expect(saveTokensMock).not.toHaveBeenCalled()
-    })
-
-    it("should not call saveTokens when scheduled refresh returns error response", async () => {
-      const mockLogger = { log: jest.fn(), error: jest.fn() }
-      const auth = createAutherClient({ logger: mockLogger })
-
-      fetch.mockResponseOnce(JSON.stringify({ error: "token_invalid" }), { status: 401 })
-
-      const saveTokensMock = jest.fn()
-      const { getTokens } = getAuthCallbacks()
-
-      await auth.authentication({ getTokens, saveTokens: saveTokensMock })
-
-      jest.runAllTimers()
-      // // flush microtasks from the async timer callback and fetch mock chain
-      for (let i = 0; i < 10; i += 1) { await Promise.resolve() }
-
-      expect(saveTokensMock).not.toHaveBeenCalled()
-      expect(mockLogger.error).toHaveBeenCalled()
-    })
-
-    it("should not call onError when it is not provided and scheduled refresh fails", async () => {
-      const mockLogger = { log: jest.fn(), error: jest.fn() }
-      const auth = createAutherClient({ logger: mockLogger })
-
-      fetch.mockResponseOnce(JSON.stringify({ error: "token_invalid" }), { status: 401 })
-
-      const saveTokensMock = jest.fn()
-      const { getTokens } = getAuthCallbacks()
-
-      await auth.authentication({ getTokens, saveTokens: saveTokensMock })
-
-      jest.runAllTimers()
-      for (let i = 0; i < 10; i += 1) { await Promise.resolve() }
-
-      expect(mockLogger.error).toHaveBeenCalled()
-      // should not throw when onError is not provided
-    })
-
-    it("calls onError when scheduled refresh fails", async () => {
-      const onErrorMock = jest.fn()
-      const mockLogger = { log: jest.fn(), error: jest.fn() }
-      const auth = createAutherClient({ logger: mockLogger, onError: onErrorMock })
-
-      fetch.mockResponseOnce(JSON.stringify({ error: "token_invalid" }), { status: 401 })
-
-      const saveTokensMock = jest.fn()
-      const { getTokens } = getAuthCallbacks()
-
-      await auth.authentication({ getTokens, saveTokens: saveTokensMock })
-
-      jest.runAllTimers()
-      for (let i = 0; i < 10; i += 1) { await Promise.resolve() }
-
-      expect(onErrorMock).toHaveBeenCalledWith(expect.any(Error))
-      expect(onErrorMock.mock.calls[0][0].message).toBe("refresh.failed")
     })
 
     it("returns current tokens without fetch when refreshToken changed before lock", async () => {
@@ -429,23 +284,6 @@ describe("When use auther methods", () => {
       finally {
         window.navigator.locks = savedLocks
       }
-    })
-
-    it("should set max refreshTimeout to one day", async () => {
-      const mockLogger = { log: jest.fn() }
-
-      const auth = createAutherClient({ logger: mockLogger })
-      const expiredDate = new Date()
-      expiredDate.setDate(expiredDate.getDate() + 10)
-      const callbacks = getAuthCallbacks({ accessTokenExpDate: expiredDate })
-
-      await auth.authentication(callbacks)
-
-      const expectedRefreshDate = new Date(Date.now() + 24 * 60 * 60 * 1000) // one day
-
-      expect(mockLogger.log).toHaveBeenCalledWith(
-        `Token will be refreshed at ${expectedRefreshDate} [${expectedRefreshDate.toUTCString()}]`,
-      )
     })
   })
 })


### PR DESCRIPTION
- Wrap token refresh in navigator.locks.request to prevent concurrent refresh calls across tabs
- Skip refresh if another tab already refreshed tokens
- Fall back to direct call when Web Locks API is unavailable
- Add onError callback for handling refresh errors
- Expose refreshTokens as public method