### PR TITLE
Add scheduled refresh tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cadolabs/auther-client",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "dist/auther-client.cjs.js",
   "module": "dist/auther-client.es.js",
   "description": "Client for working with auther on the frontend side",

--- a/src/client/AutherClient.js
+++ b/src/client/AutherClient.js
@@ -154,10 +154,12 @@ export class AutherClient {
       this.reschedule() // from the new exp
     }
     catch (error) {
-      // Fatal auth error (4xx: 422 reuse, expired refresh) → re-login, do not reschedule.
+      // Fatal auth error (4xx: 422 reuse, expired refresh) → re-login. The session is
+      // dead, so fully tear down: drop the lifecycle listeners too, otherwise a later
+      // focus/online would wake the scheduler and hammer the doomed refresh again.
+      // stopScheduledRefresh also resets #retries / #reportedTransient.
       if (isFatalAuthError(error)) {
-        this.#retries = 0
-        this.#reportedTransient = false
+        this.stopScheduledRefresh()
         onError?.(error)
         return
       }

--- a/src/client/AutherClient.js
+++ b/src/client/AutherClient.js
@@ -1,22 +1,5 @@
 import { decode, verify } from "../lib/jwt"
-
-const FATAL_AUTH_MESSAGES = new Set([
-  "token.expired",
-  "token.invalid",
-  "token.invalid_token",
-  "token.not_found",
-  "invalid.refresh_token",
-])
-
-// Fatal (re-login): HTTP 4xx except 429, or a local verify error thrown before the request.
-// Transient (retry/backoff): network error (no status), 5xx, 429.
-const isFatalAuthError = error => {
-  if (typeof error?.status === "number") {
-    return error.status >= 400 && error.status < 500 && error.status !== 429
-  }
-
-  return FATAL_AUTH_MESSAGES.has(error?.message)
-}
+import { isFatalAuthError } from "../lib/authErrors"
 
 export class AutherClient {
   #location = window.location

--- a/src/client/AutherClient.js
+++ b/src/client/AutherClient.js
@@ -1,4 +1,22 @@
-import { verify } from "../lib/jwt"
+import { decode, verify } from "../lib/jwt"
+
+const FATAL_AUTH_MESSAGES = new Set([
+  "token.expired",
+  "token.invalid",
+  "token.invalid_token",
+  "token.not_found",
+  "invalid.refresh_token",
+])
+
+// Fatal (re-login): HTTP 4xx except 429, or a local verify error thrown before the request.
+// Transient (retry/backoff): network error (no status), 5xx, 429.
+const isFatalAuthError = error => {
+  if (typeof error?.status === "number") {
+    return error.status >= 400 && error.status < 500 && error.status !== 429
+  }
+
+  return FATAL_AUTH_MESSAGES.has(error?.message)
+}
 
 export class AutherClient {
   #location = window.location
@@ -8,6 +26,15 @@ export class AutherClient {
   #REFRESH_PATH = "/tokens/refresh"
   #LOGIN_PATH = "/login"
   #DISPOSABLE_TOKEN_PATH = "/tokens/disposable"
+
+  #MAX_BACKOFF = 30_000
+  #TRANSIENT_REPORT_THRESHOLD = 5
+
+  #refreshTimer = null
+  #scheduleCtx = null
+  #lifecycleCleanup = null
+  #retries = 0
+  #reportedTransient = false
 
   constructor ({ redirectUri, autherUrl, http, appcode, logger }) {
     this.redirectUri = redirectUri
@@ -41,7 +68,14 @@ export class AutherClient {
       const response = await this.updateTokens(refreshToken)
 
       if (!response.ok) {
-        throw new Error("refresh.failed")
+        const error = new Error("refresh.failed")
+        error.status = response.status
+        try {
+          const body = await response.clone().json()
+          if (body?.code) error.serverCode = body.code
+        }
+        catch {}
+        throw error
       }
 
       const tokens = await response.json()
@@ -115,5 +149,107 @@ export class AutherClient {
       body: { id },
       headers,
     })
+  }
+
+  #computeDelay = () => {
+    const { getTokens, ratio, minBuffer } = this.#scheduleCtx
+    const { payload } = decode(getTokens().accessToken) // exp/iat in seconds
+    const now = Date.now()
+    const byRatio = (payload.iat + (payload.exp - payload.iat) * ratio) * 1000
+    const byBuffer = payload.exp * 1000 - minBuffer
+
+    return Math.max(0, Math.min(byRatio, byBuffer) - now)
+  }
+
+  #tick = async () => {
+    const { getTokens, saveTokens, onError, onTransientFailure } = this.#scheduleCtx
+
+    try {
+      await this.refreshTokens({ getTokens, saveTokens })
+      this.#retries = 0
+      this.#reportedTransient = false
+      this.reschedule() // from the new exp
+    }
+    catch (error) {
+      // Fatal auth error (4xx: 422 reuse, expired refresh) → re-login, do not reschedule.
+      if (isFatalAuthError(error)) {
+        this.#retries = 0
+        this.#reportedTransient = false
+        onError?.(error)
+        return
+      }
+
+      // Transient (network/5xx): retry with exponential backoff.
+      const backoff = Math.min(this.#MAX_BACKOFF, 1000 * 2 ** this.#retries)
+      this.#retries += 1
+
+      // Report a persisting outage once per series.
+      if (this.#retries >= this.#TRANSIENT_REPORT_THRESHOLD && !this.#reportedTransient) {
+        this.#reportedTransient = true
+        error.attempts = this.#retries
+        onTransientFailure?.(error)
+      }
+
+      clearTimeout(this.#refreshTimer)
+      this.#refreshTimer = setTimeout(this.#tick, backoff)
+    }
+  }
+
+  // Public: called both internally (after a tick) and from the host app (cross-tab resync).
+  reschedule = () => {
+    if (!this.#scheduleCtx) return
+
+    clearTimeout(this.#refreshTimer)
+
+    let delay
+    try {
+      delay = this.#computeDelay()
+    }
+    catch (error) {
+      // Missing/broken token — do not schedule, surface to the host app.
+      this.#scheduleCtx.onError?.(error)
+      return
+    }
+
+    this.#refreshTimer = setTimeout(this.#tick, delay)
+  }
+
+  startScheduledRefresh = ({
+    getTokens,
+    saveTokens,
+    onError,
+    onTransientFailure,
+    ratio = 0.75,
+    minBuffer = 30_000,
+    watchLifecycle = true,
+  }) => {
+    this.stopScheduledRefresh()
+    this.#scheduleCtx = { getTokens, saveTokens, onError, onTransientFailure, ratio, minBuffer }
+
+    if (watchLifecycle && typeof window !== "undefined") {
+      const onWake = () => {
+        if (typeof document !== "undefined" && document.visibilityState === "hidden") return
+        this.reschedule() // expired token → delay 0 → tick immediately
+      }
+
+      document.addEventListener("visibilitychange", onWake)
+      window.addEventListener("online", onWake)
+      this.#lifecycleCleanup = () => {
+        document.removeEventListener("visibilitychange", onWake)
+        window.removeEventListener("online", onWake)
+      }
+    }
+
+    this.reschedule()
+  }
+
+  stopScheduledRefresh = () => {
+    clearTimeout(this.#refreshTimer)
+    this.#refreshTimer = null
+    this.#lifecycleCleanup?.()
+    this.#lifecycleCleanup = null
+    this.#scheduleCtx = null
+    this.#retries = 0
+    this.#reportedTransient = false
   }
 }

--- a/src/client/AutherClient.js
+++ b/src/client/AutherClient.js
@@ -145,15 +145,24 @@ export class AutherClient {
   }
 
   #tick = async () => {
-    const { getTokens, saveTokens, onError, onTransientFailure } = this.#scheduleCtx
+    // Pin the context this tick belongs to. refreshTokens() awaits, and during that
+    // await the host may stopScheduledRefresh() (or restart with a fresh context).
+    // If that happened, this tick is stale: bail out so we neither re-arm a timer
+    // nor invoke callbacks that the host already detached.
+    const ctx = this.#scheduleCtx
+    if (!ctx) return
+    const { getTokens, saveTokens, onError, onTransientFailure } = ctx
 
     try {
       await this.refreshTokens({ getTokens, saveTokens })
+      if (this.#scheduleCtx !== ctx) return
       this.#retries = 0
       this.#reportedTransient = false
       this.reschedule() // from the new exp
     }
     catch (error) {
+      if (this.#scheduleCtx !== ctx) return
+
       // Fatal auth error (4xx: 422 reuse, expired refresh) → re-login. The session is
       // dead, so fully tear down: drop the lifecycle listeners too, otherwise a later
       // focus/online would wake the scheduler and hammer the doomed refresh again.

--- a/src/client/AutherClient.js
+++ b/src/client/AutherClient.js
@@ -150,7 +150,6 @@ export class AutherClient {
     // If that happened, this tick is stale: bail out so we neither re-arm a timer
     // nor invoke callbacks that the host already detached.
     const ctx = this.#scheduleCtx
-    if (!ctx) return
     const { getTokens, saveTokens, onError, onTransientFailure } = ctx
 
     try {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import * as token from "./lib/jwt"
 import AutherClient from "./client"
+import { isFatalAuthError } from "./lib/authErrors"
 
-export { AutherClient, token }
+export { AutherClient, token, isFatalAuthError }

--- a/src/lib/authErrors.js
+++ b/src/lib/authErrors.js
@@ -1,0 +1,17 @@
+const FATAL_AUTH_MESSAGES = new Set([
+  "token.expired",
+  "token.invalid",
+  "token.invalid_token",
+  "token.not_found",
+  "invalid.refresh_token",
+])
+
+// Fatal (re-login): HTTP 4xx except 429, or a local verify error thrown before the request.
+// Transient (retry/backoff): network error (no status), 5xx, 429.
+export const isFatalAuthError = error => {
+  if (typeof error?.status === "number") {
+    return error.status >= 400 && error.status < 500 && error.status !== 429
+  }
+
+  return FATAL_AUTH_MESSAGES.has(error?.message)
+}

--- a/tests/authErrors.test.js
+++ b/tests/authErrors.test.js
@@ -1,0 +1,34 @@
+import { isFatalAuthError } from "../src"
+
+describe("isFatalAuthError", () => {
+  it("classifies 4xx (except 429) as fatal", () => {
+    expect(isFatalAuthError({ status: 400 })).toBe(true)
+    expect(isFatalAuthError({ status: 401 })).toBe(true)
+    expect(isFatalAuthError({ status: 422 })).toBe(true)
+    expect(isFatalAuthError({ status: 499 })).toBe(true)
+  })
+
+  it("classifies 429 as transient", () => {
+    expect(isFatalAuthError({ status: 429 })).toBe(false)
+  })
+
+  it("classifies 5xx and network errors as transient", () => {
+    expect(isFatalAuthError({ status: 500 })).toBe(false)
+    expect(isFatalAuthError({ status: 503 })).toBe(false)
+    expect(isFatalAuthError(new Error("network down"))).toBe(false)
+  })
+
+  it("classifies local verify/refresh-token errors as fatal by message", () => {
+    expect(isFatalAuthError(new Error("token.expired"))).toBe(true)
+    expect(isFatalAuthError(new Error("token.invalid"))).toBe(true)
+    expect(isFatalAuthError(new Error("token.invalid_token"))).toBe(true)
+    expect(isFatalAuthError(new Error("token.not_found"))).toBe(true)
+    expect(isFatalAuthError(new Error("invalid.refresh_token"))).toBe(true)
+  })
+
+  it("treats unknown thrown errors as transient", () => {
+    expect(isFatalAuthError(new Error("anything else"))).toBe(false)
+    expect(isFatalAuthError(undefined)).toBe(false)
+    expect(isFatalAuthError(null)).toBe(false)
+  })
+})

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -686,9 +686,9 @@ describe("Scheduled token refresh", () => {
     auth.startScheduledRefresh({ getTokens, saveTokens, onError, onTransientFailure })
 
     await advance(750_000) // attempt 1 → backoff 1s
-    await advance(1_000)   // attempt 2 → backoff 2s
-    await advance(2_000)   // attempt 3 → backoff 4s
-    await advance(4_000)   // attempt 4 → backoff 8s
+    await advance(1_000) // attempt 2 → backoff 2s
+    await advance(2_000) // attempt 3 → backoff 4s
+    await advance(4_000) // attempt 4 → backoff 8s
 
     expect(fetch).toHaveBeenCalledTimes(4)
     expect(onError).not.toHaveBeenCalled()
@@ -707,11 +707,11 @@ describe("Scheduled token refresh", () => {
     auth.startScheduledRefresh({ getTokens, saveTokens, onError, onTransientFailure })
 
     await advance(750_000) // 1
-    await advance(1_000)   // 2
-    await advance(2_000)   // 3
-    await advance(4_000)   // 4
-    await advance(8_000)   // 5 → report
-    await advance(16_000)  // 6 → silent
+    await advance(1_000) // 2
+    await advance(2_000) // 3
+    await advance(4_000) // 4
+    await advance(8_000) // 5 → report
+    await advance(16_000) // 6 → silent
 
     expect(onError).not.toHaveBeenCalled()
     expect(onTransientFailure).toHaveBeenCalledTimes(1)
@@ -752,21 +752,21 @@ describe("Scheduled token refresh", () => {
     auth.startScheduledRefresh({ getTokens, saveTokens, onTransientFailure })
 
     await advance(750_000) // 1
-    await advance(1_000)   // 2
-    await advance(2_000)   // 3
-    await advance(4_000)   // 4
-    await advance(8_000)   // 5 → first report; counter still pinned at 5
-    await advance(16_000)  // success → counter resets, scheduler re-arms from new exp
+    await advance(1_000) // 2
+    await advance(2_000) // 3
+    await advance(4_000) // 4
+    await advance(8_000) // 5 → first report; counter still pinned at 5
+    await advance(16_000) // success → counter resets, scheduler re-arms from new exp
 
     expect(onTransientFailure).toHaveBeenCalledTimes(1)
 
     // After success the scheduler re-arms from the fresh-token exp (iat+1000s, exp+3000s),
     // so the next tick is ~1.72M ms away. Advance generously, then run the backoff steps.
     await advance(2_000_000) // burst-2 attempt 1
-    await advance(1_000)     // 2
-    await advance(2_000)     // 3
-    await advance(4_000)     // 4
-    await advance(8_000)     // 5 → second report
+    await advance(1_000) // 2
+    await advance(2_000) // 3
+    await advance(4_000) // 4
+    await advance(8_000) // 5 → second report
 
     expect(onTransientFailure).toHaveBeenCalledTimes(2)
     expect(onTransientFailure.mock.calls[1][0].attempts).toBe(5)

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -580,6 +580,61 @@ describe("Scheduled token refresh", () => {
     auth.stopScheduledRefresh()
   })
 
+  it("does not re-arm a backoff timer when stopped during an in-flight tick", async () => {
+    // Make the refresh hang so we can stop the scheduler mid-flight, then reject it.
+    let rejectRefresh
+    fetch.mockImplementationOnce(() => new Promise((_resolve, reject) => {
+      rejectRefresh = reject
+    }))
+    const onError = jest.fn()
+    const onTransientFailure = jest.fn()
+    const { getTokens, saveTokens } = makeStore(1000)
+    const auth = createAutherClient()
+
+    auth.startScheduledRefresh({ getTokens, saveTokens, onError, onTransientFailure })
+
+    await advance(750_000) // tick fires and awaits the still-pending refresh
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    // The host tears the scheduler down while the refresh is still in flight.
+    auth.stopScheduledRefresh()
+    expect(jest.getTimerCount()).toBe(0)
+
+    // Now the awaited refresh rejects with a transient error. The stale tick must
+    // not resurrect the scheduler with a fresh backoff timer.
+    rejectRefresh(new Error("network down"))
+    for (let i = 0; i < 20; i += 1) await Promise.resolve()
+
+    expect(jest.getTimerCount()).toBe(0)
+    expect(onTransientFailure).not.toHaveBeenCalled()
+  })
+
+  it("does not call onError when stopped during an in-flight tick that fails fatally", async () => {
+    let rejectRefresh
+    fetch.mockImplementationOnce(() => new Promise((_resolve, reject) => {
+      rejectRefresh = reject
+    }))
+    const onError = jest.fn()
+    const { getTokens, saveTokens } = makeStore(1000)
+    const auth = createAutherClient()
+
+    auth.startScheduledRefresh({ getTokens, saveTokens, onError })
+
+    await advance(750_000)
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    auth.stopScheduledRefresh()
+
+    // A fatal auth error arrives after the host already stopped the scheduler.
+    const fatal = new Error("refresh.failed")
+    fatal.status = 422
+    rejectRefresh(fatal)
+    for (let i = 0; i < 20; i += 1) await Promise.resolve()
+
+    expect(onError).not.toHaveBeenCalled()
+    expect(jest.getTimerCount()).toBe(0)
+  })
+
   it("treats a local verify error as fatal and does not call a missing onError", async () => {
     const { getTokens, saveTokens, setRefresh } = makeStore(1000)
     setRefresh("not-a-jwt") // verify(refreshToken) throws token.invalid_token

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -555,6 +555,31 @@ describe("Scheduled token refresh", () => {
     auth.stopScheduledRefresh()
   })
 
+  it("stops watching lifecycle after a fatal error, so 'online' does not re-trigger a refresh", async () => {
+    fetch.mockResponse(JSON.stringify({ error: "session.invalid" }), { status: 422 })
+    const onError = jest.fn()
+    const { getTokens, saveTokens, setAccess } = makeStore(1000)
+    const auth = createAutherClient()
+
+    auth.startScheduledRefresh({ getTokens, saveTokens, onError })
+
+    await advance(750_000) // tick → fatal 422
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(onError).toHaveBeenCalledTimes(1)
+
+    // Session is dead. Even if the token is now expired and the tab comes back online,
+    // the scheduler must not wake up and hammer the refresh endpoint again.
+    setAccess(buildToken({ iatOffset: -2000, expOffset: -1000 })) // expired
+    window.dispatchEvent(new Event("online"))
+    await advance(1)
+
+    expect(fetch).toHaveBeenCalledTimes(1) // no re-attempt
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(jest.getTimerCount()).toBe(0)
+
+    auth.stopScheduledRefresh()
+  })
+
   it("treats a local verify error as fatal and does not call a missing onError", async () => {
     const { getTokens, saveTokens, setRefresh } = makeStore(1000)
     setRefresh("not-a-jwt") // verify(refreshToken) throws token.invalid_token

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -555,7 +555,7 @@ describe("Scheduled token refresh", () => {
     auth.stopScheduledRefresh()
   })
 
-  it("stops watching lifecycle after a fatal error, so 'online' does not re-trigger a refresh", async () => {
+  it("stops watching lifecycle after a fatal error, so 'online' does not refresh", async () => {
     fetch.mockResponse(JSON.stringify({ error: "session.invalid" }), { status: 422 })
     const onError = jest.fn()
     const { getTokens, saveTokens, setAccess } = makeStore(1000)

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -609,6 +609,28 @@ describe("Scheduled token refresh", () => {
     expect(onTransientFailure).not.toHaveBeenCalled()
   })
 
+  it("does not reschedule when stopped during an in-flight tick that succeeds", async () => {
+    let resolveRefresh
+    fetch.mockImplementationOnce(() => new Promise(resolve => {
+      resolveRefresh = resolve
+    }))
+    const { getTokens, saveTokens } = makeStore(1000)
+    const auth = createAutherClient()
+
+    auth.startScheduledRefresh({ getTokens, saveTokens })
+
+    await advance(750_000)
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    auth.stopScheduledRefresh()
+
+    // The refresh succeeds after teardown: the stale tick must not re-arm a timer.
+    resolveRefresh(new Response(freshTokensResponse(), { status: 200 }))
+    for (let i = 0; i < 20; i += 1) await Promise.resolve()
+
+    expect(jest.getTimerCount()).toBe(0)
+  })
+
   it("does not call onError when stopped during an in-flight tick that fails fatally", async () => {
     let rejectRefresh
     fetch.mockImplementationOnce(() => new Promise((_resolve, reject) => {

--- a/tests/client.test.js
+++ b/tests/client.test.js
@@ -332,6 +332,52 @@ describe("When params is missing", () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  it("attaches the HTTP status to a failed refresh error", async () => {
+    window.navigator.locks = { request: (_name, callback) => callback() }
+    fetch.resetMocks()
+    fetch.mockResponseOnce(JSON.stringify({ error: "session.invalid" }), { status: 422 })
+
+    const auth = createAutherClient()
+    const expiredDate = new Date()
+    expiredDate.setHours(expiredDate.getHours() - 3)
+    const { getTokens } = getAuthCallbacks({ accessTokenExpDate: expiredDate })
+
+    await auth.refreshTokens({ getTokens, saveTokens: jest.fn() }).catch(error => {
+      expect(error.message).toBe("refresh.failed")
+      expect(error.status).toBe(422)
+    })
+    expect.assertions(2)
+  })
+
+  it("exposes the server code from the response body on a failed refresh", async () => {
+    window.navigator.locks = { request: (_name, callback) => callback() }
+    fetch.resetMocks()
+    fetch.mockResponseOnce(JSON.stringify({ code: "session.invalid" }), { status: 422 })
+
+    const auth = createAutherClient()
+    const { getTokens } = getAuthCallbacks()
+
+    await auth.refreshTokens({ getTokens, saveTokens: jest.fn() }).catch(error => {
+      expect(error.serverCode).toBe("session.invalid")
+    })
+    expect.assertions(1)
+  })
+
+  it("leaves serverCode undefined when the response body is not JSON", async () => {
+    window.navigator.locks = { request: (_name, callback) => callback() }
+    fetch.resetMocks()
+    fetch.mockResponseOnce("not json", { status: 500 })
+
+    const auth = createAutherClient()
+    const { getTokens } = getAuthCallbacks()
+
+    await auth.refreshTokens({ getTokens, saveTokens: jest.fn() }).catch(error => {
+      expect(error.status).toBe(500)
+      expect(error.serverCode).toBeUndefined()
+    })
+    expect.assertions(2)
+  })
+
   it("should not start the update timer", async () => {
     const mockLogger = { log: jest.fn() }
 
@@ -350,5 +396,381 @@ describe("When params is missing", () => {
     expect(mockLogger.log).not.toHaveBeenCalledWith(
       `Token will be refreshed at ${expectedRefreshDate} [${expectedRefreshDate.toUTCString()}]`,
     )
+  })
+})
+
+describe("Scheduled token refresh", () => {
+  const NOW = 1_700_000_000_000 // fixed wall clock for deterministic timers
+
+  const buildToken = ({ iatOffset = 0, expOffset, type = "access" }) => {
+    const iat = NOW / 1000 + iatOffset
+    const exp = NOW / 1000 + expOffset
+    const payload = btoa(JSON.stringify({ iat, exp, type }))
+    const header = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+    return `${header}.${payload}.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c`
+  }
+
+  const makeStore = (accessExpOffset = 1000) => {
+    let accessToken = buildToken({ expOffset: accessExpOffset })
+    let refreshToken = buildToken({ expOffset: 5000, type: "refresh" })
+
+    return {
+      getTokens: () => ({ accessToken, refreshToken }),
+      saveTokens: tokens => {
+        if (tokens.accessToken) accessToken = tokens.accessToken
+        if (tokens.refreshToken) refreshToken = tokens.refreshToken
+      },
+      setAccess: value => { accessToken = value },
+      setRefresh: value => { refreshToken = value },
+    }
+  }
+
+  const freshTokensResponse = () => JSON.stringify({
+    accessToken: buildToken({ iatOffset: 1000, expOffset: 3000 }),
+    refreshToken: buildToken({ iatOffset: 1000, expOffset: 6000, type: "refresh" }),
+  })
+
+  // jest 29.2 has no advanceTimersByTimeAsync: advance fake timers, then drain microtasks
+  // so the async tick bodies (refresh → catch/reschedule) settle before assertions.
+  const advance = async ms => {
+    jest.advanceTimersByTime(ms)
+    for (let i = 0; i < 20; i += 1) {
+      await Promise.resolve()
+    }
+  }
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    jest.setSystemTime(NOW)
+    fetch.resetMocks()
+    window.navigator.locks = { request: (_name, callback) => callback() }
+  })
+
+  afterEach(() => {
+    jest.clearAllTimers()
+    jest.useRealTimers()
+  })
+
+  it("schedules the refresh by ratio/minBuffer and fires before exp", async () => {
+    fetch.mockResponse(freshTokensResponse())
+    const { getTokens, saveTokens } = makeStore(1000) // lifetime 1000s
+    const auth = createAutherClient()
+
+    // byRatio = iat + 1000 * 0.75 = +750s; byBuffer = exp - 30s = +970s → ratio wins
+    auth.startScheduledRefresh({ getTokens, saveTokens, ratio: 0.75, minBuffer: 30_000 })
+
+    await advance(749_999)
+    expect(fetch).not.toHaveBeenCalled()
+
+    await advance(1)
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    auth.stopScheduledRefresh()
+  })
+
+  it("reschedules from the new exp after a successful tick", async () => {
+    fetch.mockResponse(freshTokensResponse())
+    const { getTokens, saveTokens } = makeStore(1000)
+    const auth = createAutherClient()
+
+    auth.startScheduledRefresh({ getTokens, saveTokens })
+
+    await advance(750_000)
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(jest.getTimerCount()).toBe(1) // a new timer was armed from the fresh token
+
+    auth.stopScheduledRefresh()
+    expect(jest.getTimerCount()).toBe(0)
+  })
+
+  it("retries with backoff on a network error and resets after success", async () => {
+    fetch.mockRejectOnce(new Error("network down"))
+    fetch.mockResponseOnce(freshTokensResponse())
+    const onError = jest.fn()
+    const { getTokens, saveTokens } = makeStore(1000)
+    const auth = createAutherClient()
+
+    auth.startScheduledRefresh({ getTokens, saveTokens, onError })
+
+    await advance(750_000) // tick → reject → backoff 1000ms
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    await advance(1000) // retry → success
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(onError).not.toHaveBeenCalled()
+
+    auth.stopScheduledRefresh()
+  })
+
+  it("treats 5xx as transient and retries", async () => {
+    fetch.mockResponseOnce(JSON.stringify({ error: "boom" }), { status: 503 })
+    fetch.mockResponseOnce(freshTokensResponse())
+    const onError = jest.fn()
+    const { getTokens, saveTokens } = makeStore(1000)
+    const auth = createAutherClient()
+
+    auth.startScheduledRefresh({ getTokens, saveTokens, onError })
+
+    await advance(750_000)
+    await advance(1000)
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(onError).not.toHaveBeenCalled()
+
+    auth.stopScheduledRefresh()
+  })
+
+  it("treats 429 as transient and retries", async () => {
+    fetch.mockResponseOnce(JSON.stringify({ error: "slow down" }), { status: 429 })
+    fetch.mockResponseOnce(freshTokensResponse())
+    const onError = jest.fn()
+    const { getTokens, saveTokens } = makeStore(1000)
+    const auth = createAutherClient()
+
+    auth.startScheduledRefresh({ getTokens, saveTokens, onError })
+
+    await advance(750_000)
+    await advance(1000)
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(onError).not.toHaveBeenCalled()
+
+    auth.stopScheduledRefresh()
+  })
+
+  it("routes a fatal 422 to onError without rescheduling", async () => {
+    fetch.mockResponse(JSON.stringify({ error: "session.invalid" }), { status: 422 })
+    const onError = jest.fn()
+    const { getTokens, saveTokens } = makeStore(1000)
+    const auth = createAutherClient()
+
+    auth.startScheduledRefresh({ getTokens, saveTokens, onError })
+
+    await advance(750_000)
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(onError.mock.calls[0][0].status).toBe(422)
+    expect(jest.getTimerCount()).toBe(0) // not rescheduled
+
+    auth.stopScheduledRefresh()
+  })
+
+  it("treats a local verify error as fatal and does not call a missing onError", async () => {
+    const { getTokens, saveTokens, setRefresh } = makeStore(1000)
+    setRefresh("not-a-jwt") // verify(refreshToken) throws token.invalid_token
+    const auth = createAutherClient()
+
+    // no onError provided → must not throw
+    auth.startScheduledRefresh({ getTokens, saveTokens })
+
+    await advance(750_000)
+    expect(fetch).not.toHaveBeenCalled()
+    expect(jest.getTimerCount()).toBe(0)
+
+    auth.stopScheduledRefresh()
+  })
+
+  it("calls onError when the access token cannot be decoded", () => {
+    const onError = jest.fn()
+    const { getTokens, saveTokens, setAccess } = makeStore(1000)
+    setAccess("broken") // decode throws
+
+    const auth = createAutherClient()
+    auth.startScheduledRefresh({ getTokens, saveTokens, onError })
+
+    expect(onError).toHaveBeenCalledTimes(1)
+    expect(jest.getTimerCount()).toBe(0)
+
+    auth.stopScheduledRefresh()
+  })
+
+  it("does not throw on a decode error when onError is absent", () => {
+    const { getTokens, saveTokens, setAccess } = makeStore(1000)
+    setAccess("broken")
+
+    const auth = createAutherClient()
+    expect(() => auth.startScheduledRefresh({ getTokens, saveTokens })).not.toThrow()
+
+    auth.stopScheduledRefresh()
+  })
+
+  it("is a no-op when reschedule is called without an active context", () => {
+    const auth = createAutherClient()
+    expect(() => auth.reschedule()).not.toThrow()
+    expect(jest.getTimerCount()).toBe(0)
+  })
+
+  it("registers and removes lifecycle listeners", () => {
+    const windowAdd = jest.spyOn(window, "addEventListener")
+    const windowRemove = jest.spyOn(window, "removeEventListener")
+    const docAdd = jest.spyOn(document, "addEventListener")
+    const docRemove = jest.spyOn(document, "removeEventListener")
+
+    const { getTokens, saveTokens } = makeStore(1000)
+    const auth = createAutherClient()
+
+    auth.startScheduledRefresh({ getTokens, saveTokens })
+    expect(docAdd).toHaveBeenCalledWith("visibilitychange", expect.any(Function))
+    expect(windowAdd).toHaveBeenCalledWith("online", expect.any(Function))
+
+    auth.stopScheduledRefresh()
+    expect(docRemove).toHaveBeenCalledWith("visibilitychange", expect.any(Function))
+    expect(windowRemove).toHaveBeenCalledWith("online", expect.any(Function))
+
+    windowAdd.mockRestore()
+    windowRemove.mockRestore()
+    docAdd.mockRestore()
+    docRemove.mockRestore()
+  })
+
+  it("does not register lifecycle listeners when watchLifecycle is false", () => {
+    const windowAdd = jest.spyOn(window, "addEventListener")
+    const docAdd = jest.spyOn(document, "addEventListener")
+
+    const { getTokens, saveTokens } = makeStore(1000)
+    const auth = createAutherClient()
+
+    auth.startScheduledRefresh({ getTokens, saveTokens, watchLifecycle: false })
+
+    expect(windowAdd).not.toHaveBeenCalledWith("online", expect.any(Function))
+    expect(docAdd).not.toHaveBeenCalledWith("visibilitychange", expect.any(Function))
+
+    auth.stopScheduledRefresh() // covers the absent-cleanup branch
+    windowAdd.mockRestore()
+    docAdd.mockRestore()
+  })
+
+  it("catches up on the 'online' event when the token is expired", async () => {
+    fetch.mockResponse(freshTokensResponse())
+    const { getTokens, saveTokens, setAccess } = makeStore(1000)
+    const auth = createAutherClient()
+
+    auth.startScheduledRefresh({ getTokens, saveTokens }) // far timer for the valid token
+    setAccess(buildToken({ iatOffset: -2000, expOffset: -1000 })) // now expired
+
+    window.dispatchEvent(new Event("online"))
+    await advance(1) // delay 0 → immediate tick
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    auth.stopScheduledRefresh()
+  })
+
+  it("ignores visibilitychange while the document is hidden, catches up when visible", async () => {
+    fetch.mockResponse(freshTokensResponse())
+    const { getTokens, saveTokens, setAccess } = makeStore(1000)
+    const auth = createAutherClient()
+
+    auth.startScheduledRefresh({ getTokens, saveTokens })
+    setAccess(buildToken({ iatOffset: -2000, expOffset: -1000 })) // expired
+
+    Object.defineProperty(document, "visibilityState", { value: "hidden", configurable: true })
+    document.dispatchEvent(new Event("visibilitychange"))
+    await advance(1)
+    expect(fetch).not.toHaveBeenCalled() // hidden → no catch-up
+
+    Object.defineProperty(document, "visibilityState", { value: "visible", configurable: true })
+    document.dispatchEvent(new Event("visibilitychange"))
+    await advance(1)
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    auth.stopScheduledRefresh()
+  })
+
+  it("does not call onTransientFailure for the first four transient failures", async () => {
+    for (let i = 0; i < 4; i += 1) fetch.mockRejectOnce(new Error("network down"))
+    const onError = jest.fn()
+    const onTransientFailure = jest.fn()
+    const { getTokens, saveTokens } = makeStore(1000)
+    const auth = createAutherClient()
+
+    auth.startScheduledRefresh({ getTokens, saveTokens, onError, onTransientFailure })
+
+    await advance(750_000) // attempt 1 → backoff 1s
+    await advance(1_000)   // attempt 2 → backoff 2s
+    await advance(2_000)   // attempt 3 → backoff 4s
+    await advance(4_000)   // attempt 4 → backoff 8s
+
+    expect(fetch).toHaveBeenCalledTimes(4)
+    expect(onError).not.toHaveBeenCalled()
+    expect(onTransientFailure).not.toHaveBeenCalled()
+
+    auth.stopScheduledRefresh()
+  })
+
+  it("reports the transient outage once on the fifth consecutive failure", async () => {
+    for (let i = 0; i < 6; i += 1) fetch.mockRejectOnce(new Error("network down"))
+    const onError = jest.fn()
+    const onTransientFailure = jest.fn()
+    const { getTokens, saveTokens } = makeStore(1000)
+    const auth = createAutherClient()
+
+    auth.startScheduledRefresh({ getTokens, saveTokens, onError, onTransientFailure })
+
+    await advance(750_000) // 1
+    await advance(1_000)   // 2
+    await advance(2_000)   // 3
+    await advance(4_000)   // 4
+    await advance(8_000)   // 5 → report
+    await advance(16_000)  // 6 → silent
+
+    expect(onError).not.toHaveBeenCalled()
+    expect(onTransientFailure).toHaveBeenCalledTimes(1)
+    const reported = onTransientFailure.mock.calls[0][0]
+    expect(reported.attempts).toBe(5)
+    expect(reported.message).toBe("network down")
+
+    auth.stopScheduledRefresh()
+  })
+
+  it("does not throw when onTransientFailure is not provided", async () => {
+    for (let i = 0; i < 5; i += 1) fetch.mockRejectOnce(new Error("network down"))
+    const { getTokens, saveTokens } = makeStore(1000)
+    const auth = createAutherClient()
+
+    auth.startScheduledRefresh({ getTokens, saveTokens }) // no callbacks
+
+    await advance(750_000)
+    await advance(1_000)
+    await advance(2_000)
+    await advance(4_000)
+    await expect(advance(8_000)).resolves.not.toThrow()
+
+    auth.stopScheduledRefresh()
+  })
+
+  it("resets the transient report flag after a successful refresh", async () => {
+    // first burst: 5 failures → 1 report, then success
+    for (let i = 0; i < 5; i += 1) fetch.mockRejectOnce(new Error("down"))
+    fetch.mockResponseOnce(freshTokensResponse())
+    // second burst: 5 failures → another report
+    for (let i = 0; i < 5; i += 1) fetch.mockRejectOnce(new Error("down again"))
+
+    const onTransientFailure = jest.fn()
+    const { getTokens, saveTokens } = makeStore(1000)
+    const auth = createAutherClient()
+
+    auth.startScheduledRefresh({ getTokens, saveTokens, onTransientFailure })
+
+    await advance(750_000) // 1
+    await advance(1_000)   // 2
+    await advance(2_000)   // 3
+    await advance(4_000)   // 4
+    await advance(8_000)   // 5 → first report; counter still pinned at 5
+    await advance(16_000)  // success → counter resets, scheduler re-arms from new exp
+
+    expect(onTransientFailure).toHaveBeenCalledTimes(1)
+
+    // After success the scheduler re-arms from the fresh-token exp (iat+1000s, exp+3000s),
+    // so the next tick is ~1.72M ms away. Advance generously, then run the backoff steps.
+    await advance(2_000_000) // burst-2 attempt 1
+    await advance(1_000)     // 2
+    await advance(2_000)     // 3
+    await advance(4_000)     // 4
+    await advance(8_000)     // 5 → second report
+
+    expect(onTransientFailure).toHaveBeenCalledTimes(2)
+    expect(onTransientFailure.mock.calls[1][0].attempts).toBe(5)
+
+    auth.stopScheduledRefresh()
   })
 })


### PR DESCRIPTION
Adds a self-rescheduling token refresh to `AutherClient`
  (`startScheduledRefresh` / `stopScheduledRefresh`):

  - refreshes by `ratio` of the token lifetime, capped by `minBuffer` before `exp`
  - transient failures (network / 5xx / 429) retry with exponential backoff;
    fatal ones (4xx) surface via `onError` for re-login
  - `visibilitychange` / `online` catch up an expired token;
  - exports `isFatalAuthError`; `refresh.failed` now carries `status` / `serverCode`